### PR TITLE
Carpenter port

### DIFF
--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -2011,7 +2011,7 @@ directory, NOT in this subdirectory."""
         if (
             executable is not None
             and "aprun" in executable
-            and not "theta" in self.get_value("MACH") and not "onyx" in self.get_value("MACH") and not "warhawk" in self.get_value("MACH") and not "blackbird" in self.get_value("MACH") and not "narwhal" in self.get_value("MACH")
+            and not "theta" in self.get_value("MACH") and not "onyx" in self.get_value("MACH") and not "warhawk" in self.get_value("MACH") and not "blackbird" in self.get_value("MACH") and not "narwhal" in self.get_value("MACH") and not "carpenter" in self.get_value("MACH")
         ):
             aprun_args, num_nodes = get_aprun_cmd_for_case(
                 self, run_exe, overrides=overrides


### PR DESCRIPTION
Will be creating an E3SM PR for E3SMv2.1-Arctic as well.

What we really need is

https://github.com/ESMCI/cime/pull/4343

dated Dec, 2022.  Our branch seems to be up to date with master to #4322, Oct 2022.  If we updated cime (or pulled in PR 4343), we could avoid these cime port issues in the future.